### PR TITLE
Fixed miscounting of password lengths

### DIFF
--- a/pipal.rb
+++ b/pipal.rb
@@ -363,7 +363,7 @@ catch :ctrl_c do
 				end
 
 				if lengths[line.length].nil?
-					lengths[line.length] = 1
+					lengths[line.length] = 0
 				end
 				lengths[line.length] += 1
 


### PR DESCRIPTION
Fixed an issue where lines of a previously unseen length were counted twice
