### PR TITLE
Consistency in header of special checker

### DIFF
--- a/checkers_available/special_checker.rb
+++ b/checkers_available/special_checker.rb
@@ -30,7 +30,6 @@ class Special_Checker < Checker
 
 	def get_results()
 		ret_str = "Special Checker\n"
-		ret_str +="===============\n"
 		disp = false
 
 		(@list.sort do |x,y| (x[1] <=> y[1]) * -1 end).each do |special_data|


### PR DESCRIPTION
I'm trying to parse pipal output with a script and the special module is (so far) the only one which has an extra header line, which complicates parsing. Can we remove this?