### PR TITLE
Add instruction for quick fix on Windows #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ can pass it on the command line every time. If you are going to hope that you
 don't need a valid key then just put X in as the value as without something
 Pipal won't try to perform a look up.
 
+Windows
+-------
+
+Git on Windows does not support symlink. Instead, the symlinks are converted to 
+text files with the path inside. Because pipal rely on symlinks in the 
+`checkers_enabled` directory, you need to recreate the symlinks as follows.
+
+```
+> cd checkers_enabled
+> rm 01basic.rb
+> mklink 01basic.rb "../checkers_available/basic.rb"
+```
+
 Version History
 ===============
 

--- a/checkers_enabled/.gitignore
+++ b/checkers_enabled/.gitignore
@@ -2,5 +2,5 @@
 *
 # Except this file
 !.gitignore
-!README
+!README.md
 !01basic.rb

--- a/checkers_enabled/README
+++ b/checkers_enabled/README
@@ -1,5 +1,0 @@
-This directory contains the checkers you want to enable.
-
-The way I see this working is the same as Apache does with modules and sites,
-keep the checkers in the checkers_available directory but then symlink the
-ones you want to use into here.

--- a/checkers_enabled/README.md
+++ b/checkers_enabled/README.md
@@ -1,0 +1,17 @@
+This directory contains the checkers you want to enable.
+
+The way I see this working is the same as Apache does with modules and sites,
+keep the checkers in the checkers_available directory but then symlink the
+ones you want to use into here.
+
+Linux
+-----
+
+    $ ln -s 01basic.rb ../checkers_available/basic.rb
+
+Windows
+-------
+
+    $ mklink 01basic.rb "../checkers_available/basic.rb"
+
+(For version of Windows prior to Vista, you need to copy checkers manually from the `checkers_available` folder to the `checkers_enable` folder)


### PR DESCRIPTION
No change to code.
Simply add simple instruction to make pipal work on Windows.

This should close the issue #37

Tested on Windows 10