### PR TITLE
Adding colon splitting functionality

### DIFF
--- a/spliters_available/colon_user_pass.rb
+++ b/spliters_available/colon_user_pass.rb
@@ -1,0 +1,20 @@
+# Split the line on a colon with the format
+# username:password
+# useful if you're handling output from 
+# hashcat --username --outfile-format=2 options
+# and want to use the username checker.
+#
+# To use this script sym link it to
+# custom_splitter.rb in the main Pipal directory
+
+class Custom_word_splitter
+	def self.split (line)
+		if line =~ /^([^:]*)\:(.*)$/
+			username = $1
+      word = $2
+
+			return [word, {"username" => username}]
+		end
+		return [line, {}]
+	end
+end


### PR DESCRIPTION
I regularly use pipal with output from hashcat gathered via --outfile-format=2 which outputs username:password.

I usually just create this file on the fly from your pipe example, but figured that although it's an easy addition because I use it every time I download pipal that having it part of the main repo made sense :)

Output from the splitter is flipped from the pipe example. This processes an input file with the format of username:password rather than password:username.

Tested the regex using rubular over at: https://rubular.com/r/0QcSVed8QekVHI as seen below.

![image](https://user-images.githubusercontent.com/699884/159992445-13b552e0-5fd9-4ed3-80ec-aab925bdb916.png)
